### PR TITLE
fix: broken test

### DIFF
--- a/man/versionr-package.Rd
+++ b/man/versionr-package.Rd
@@ -9,6 +9,14 @@
 This package provides an S3 class designed to remove the friction
     of working with version numbers in R.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/wurli/versionr}
+  \item \url{https://wurli.github.io/versionr/}
+}
+
+}
 \author{
 \strong{Maintainer}: Jacob Scott \email{jscott2718@gmail.com}
 

--- a/tests/testthat/test-bump_version.R
+++ b/tests/testthat/test-bump_version.R
@@ -15,6 +15,4 @@ test_that("bumping fails correctly", {
   expect_error(bump_version(nums[1],       1, -2), "Version number parts cannot be negative")
   expect_error(bump_version(nums[1], "minor", -1), "Version number parts cannot be negative")
 
-  expect_warning(bump_version(nums[2], 5, 0), "Part to bump not found in version number")
-
 })


### PR DESCRIPTION
Fix a test broken by changing the warning behaviour in `bump_version()`